### PR TITLE
Issue #5: show the relevant query term in the search results:

### DIFF
--- a/PoetAssistant/src/rhymer/controller/RhymerViewController.swift
+++ b/PoetAssistant/src/rhymer/controller/RhymerViewController.swift
@@ -18,6 +18,7 @@
 */
 
 import UIKit
+import CoreData
 
 class RhymerViewController: SearchResultsController {
 	override func viewDidLoad() {
@@ -29,15 +30,13 @@ class RhymerViewController: SearchResultsController {
 	override func getEmptyText(query: String) -> String {
 		return String(format: NSLocalizedString("No rhymes for %@", comment: ""), "\(query)")
 	}
-	override func doQuery(query: String, completion: @escaping () -> Void) {
-		AppDelegate.persistentDictionariesContainer.performBackgroundTask { [weak self] context in
-			self?.fetchedResultsController = WordVariants.createRhymesFetchResultsController(context: context, queryText: query)
-			try? self?.fetchedResultsController?.performFetch()
-			DispatchQueue.main.async {
-				completion()
-			}
-		}
+
+	override func backgroundFetch(context: NSManagedObjectContext, word: String) -> Bool {
+		fetchedResultsController = WordVariants.createRhymesFetchResultsController(context: context, queryText: word)
+		try? fetchedResultsController?.performFetch()
+		return fetchedResultsController?.sections.count ?? 0 > 0
 	}
+	
 	func numberOfSections(in tableView: UITableView) -> Int {
 		return fetchedResultsController?.sections.count ?? 0
 	}

--- a/PoetAssistant/src/search/controller/SearchResultsController.swift
+++ b/PoetAssistant/src/search/controller/SearchResultsController.swift
@@ -1,29 +1,30 @@
 /**
- Copyright (c) 2018 Carmen Alvarez
+Copyright (c) 2018 Carmen Alvarez
 
- This file is part of Poet Assistant.
+This file is part of Poet Assistant.
 
- Poet Assistant is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
+Poet Assistant is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
- Poet Assistant is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+Poet Assistant is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import UIKit
+import CoreData
 
 /**
- Displays the search results for a given query
- */
+Displays the search results for a given query
+*/
 class SearchResultsController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-
+	
 	@IBOutlet weak var labelQuery: UILabel!
 	@IBOutlet weak var tableView: UITableView!{
 		didSet {
@@ -40,7 +41,7 @@ class SearchResultsController: UIViewController, UITableViewDelegate, UITableVie
 		}
 	}
 	var lexicon: Lexicon!
-
+	
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		updateUI()
@@ -49,13 +50,31 @@ class SearchResultsController: UIViewController, UITableViewDelegate, UITableVie
 	private func updateUI() {
 		labelQuery.text = query.localizedLowercase
 		if let nonEmptyQuery = labelQuery.text, !nonEmptyQuery.isEmpty {
-			doQuery(query: nonEmptyQuery, completion: { [weak self] in
-				self?.queryResultsFetched(query: nonEmptyQuery)
-			})
+			executeQuery(query: nonEmptyQuery)
 		} else {
 			emptyText.isHidden = false
 			emptyText.text = NSLocalizedString("empty_text_no_query", comment: "")
 			labelQuery.isHidden = true
+		}
+	}
+	
+	private func executeQuery(query: String) {
+		AppDelegate.persistentDictionariesContainer.performBackgroundTask { [weak self] context in
+			// No results? How about trying the stem of the word.
+			// This should probably (maybe?) be in the model, but the details can't be completely hidden
+			// from the view controller either... we need to know what was the actual query
+			// term used in the end, the original
+			// or the stem, to display something meaningful to the user:
+			// no results => show "no results for 'original term'"
+			// results => show the results for the actual term used.
+			if !(self?.backgroundFetch(context:context, word:query) ?? false) {
+				if let fallbackQuery = self?.getFallbackQuery(query: query), fallbackQuery != query {
+					if (self?.backgroundFetch(context:context, word:fallbackQuery) ?? false) {
+						DispatchQueue.main.async{self?.labelQuery.text = fallbackQuery}
+					}
+				}
+			}
+			DispatchQueue.main.async{self?.queryResultsFetched(query: query)}
 		}
 	}
 	
@@ -76,11 +95,28 @@ class SearchResultsController: UIViewController, UITableViewDelegate, UITableVie
 		return UITableView.automaticDimension
 	}
 	
+	//--------------------------------------------
+	// Methods to be implemented by the subclasses
+	//--------------------------------------------
+
+	/**
+	* Fetch the data and return true if some data was fetched.
+	*/
+	open func backgroundFetch(context: NSManagedObjectContext, word: String) -> Bool {
+		return false
+	}
+
+	/**
+	* return an optional string to query in case we find no results for the original query
+	*/
+	open func getFallbackQuery(query: String) -> String? {
+		return nil
+	}
+
 	open func getEmptyText(query: String) -> String {
 		return ""
 	}
-	open func doQuery(query: String, completion: @escaping () -> Void) {
-	}
+
 	open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
 		return 0
 	}

--- a/PoetAssistant/src/thesaurus/controller/ThesaurusViewController.swift
+++ b/PoetAssistant/src/thesaurus/controller/ThesaurusViewController.swift
@@ -18,6 +18,7 @@
 */
 
 import UIKit
+import CoreData
 
 class ThesaurusViewController: SearchResultsController {
 	
@@ -33,25 +34,15 @@ class ThesaurusViewController: SearchResultsController {
 		return String(format: NSLocalizedString("No synonyms for %@", comment: ""), "\(query)")
 	}
 	
-	override func doQuery(query: String, completion: @escaping () -> Void) {
-		AppDelegate.persistentDictionariesContainer.performBackgroundTask { [weak self] context in
-			self?.fetchedResultsController = Thesaurus.createFetchResultsController(context: context, queryText: query)
-			try? self?.fetchedResultsController?.performFetch()
-			// No results? How about trying the stem of the word.
-			if (self?.fetchedResultsController?.sections.count ?? 0) == 0 {
-				let stemmedWord = PorterStemmer().stemWord(word:query)
-				if (stemmedWord != query) {
-					DispatchQueue.main.async {
-						self?.query = stemmedWord
-					}
-					return
-				}
-			}
-			DispatchQueue.main.async {
-				completion()
-			}
-		}
+	override func backgroundFetch(context: NSManagedObjectContext, word: String) -> Bool {
+		fetchedResultsController = Thesaurus.createFetchResultsController(context: context, queryText: word)
+		try? fetchedResultsController?.performFetch()
+		return fetchedResultsController?.sections.count ?? 0 > 0
 	}
+	override func getFallbackQuery(query: String) -> String? {
+		return PorterStemmer().stemWord(word:query)
+	}
+	
 	func numberOfSections(in tableView: UITableView) -> Int {
 		return fetchedResultsController?.sections.count ?? 0
 	}


### PR DESCRIPTION
* If we have results, display the actual query term which was used (it could be the one from the user, or a stem).
* If we have no results: display the term the user selected.