### PR TITLE
Support pause tokens in tts

### DIFF
--- a/PoetAssistant.xcodeproj/project.pbxproj
+++ b/PoetAssistant.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4F054B67218DE24500386FBC /* SearchResultHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4F054B66218DE24500386FBC /* SearchResultHeaderView.xib */; };
 		4F054B6B2196ADE300386FBC /* UINavigationController+statusBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F054B6A2196ADE300386FBC /* UINavigationController+statusBarStyle.swift */; };
 		4F05BE642590DF7400DE56ED /* WidgetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05BE632590DF7400DE56ED /* WidgetUtils.swift */; };
+		4F05BE7225911B7800DE56ED /* TtsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05BE7125911B7800DE56ED /* TtsTest.swift */; };
 		4F1189C8219870A100A4308C /* RhymerSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1189C7219870A100A4308C /* RhymerSettingsTest.swift */; };
 		4F15B04C217342560072C8BC /* Tts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F15B04B217342560072C8BC /* Tts.swift */; };
 		4F1C93CA218BA71600469CD5 /* Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1C93C9218BA71600469CD5 /* Favorite.swift */; };
@@ -188,6 +189,7 @@
 		4F054B66218DE24500386FBC /* SearchResultHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchResultHeaderView.xib; sourceTree = "<group>"; };
 		4F054B6A2196ADE300386FBC /* UINavigationController+statusBarStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+statusBarStyle.swift"; sourceTree = "<group>"; };
 		4F05BE632590DF7400DE56ED /* WidgetUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetUtils.swift; sourceTree = "<group>"; };
+		4F05BE7125911B7800DE56ED /* TtsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TtsTest.swift; sourceTree = "<group>"; };
 		4F1189C7219870A100A4308C /* RhymerSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RhymerSettingsTest.swift; sourceTree = "<group>"; };
 		4F15B04B217342560072C8BC /* Tts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tts.swift; sourceTree = "<group>"; };
 		4F1C93C8218BA0FA00469CD5 /* userdata 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "userdata 2.xcdatamodel"; sourceTree = "<group>"; };
@@ -526,6 +528,7 @@
 				4FEF06C321851C0D00D69383 /* FileUtilsTest.swift */,
 				4F2CE7DD21A994E700EB2AF3 /* WotdTest.swift */,
 				4F4B777F21D7A6EA00FCE173 /* ThesaurusTest.swift */,
+				4F05BE7125911B7800DE56ED /* TtsTest.swift */,
 			);
 			path = PoetAssistantTests;
 			sourceTree = "<group>";
@@ -1119,6 +1122,7 @@
 				4F4B778021D7A6EA00FCE173 /* ThesaurusTest.swift in Sources */,
 				4F3197632167E4ED00135FF4 /* PorterStemmerTest.swift in Sources */,
 				4F2CE7DE21A994E700EB2AF3 /* WotdTest.swift in Sources */,
+				4F05BE7225911B7800DE56ED /* TtsTest.swift in Sources */,
 				4FFBA5C0216A5C7A00AD3AD6 /* WordCountTest.swift in Sources */,
 				4FEB03B82177BB7100CF8B49 /* StemsTest.swift in Sources */,
 				4FEF06C421851C0D00D69383 /* FileUtilsTest.swift in Sources */,

--- a/PoetAssistant/src/tts/Tts.swift
+++ b/PoetAssistant/src/tts/Tts.swift
@@ -20,17 +20,80 @@ along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
 import AVFoundation
 
 class Tts {
+	private static let PAUSE_DURATION_S = TimeInterval(0.5)
+
 	class func createUtterance(text: String) -> AVSpeechUtterance {
 		return createUtterance(text:text, voiceIdentifier: Settings.getVoiceIdentifier())
 	}
 	
-	class func createUtterance(text: String, voiceIdentifier: String?) -> AVSpeechUtterance {
+	class func createUtterance(text: String, voiceIdentifier: String?, preDelay: TimeInterval? = nil) -> AVSpeechUtterance {
 		let utterance = AVSpeechUtterance(string: text)
 		utterance.rate = Settings.getVoiceSpeed()
 		utterance.pitchMultiplier = Settings.getVoicePitch()
+		if (preDelay != nil) {
+			utterance.preUtteranceDelay = preDelay!
+		}
 		if voiceIdentifier != nil, let voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier!) {
 			utterance.voice = voice
 		}
 		return utterance
+	}
+
+	/**
+	* Splits a string into multiple utterances for pausing playback.
+	*
+	* @param text A "..." in the input text indicates a pause, and each subsequent "." after the initial "..." indicates an additional pause.
+	*
+	* Examples:
+	* "To be or not to be... that is the question":  1 pause:  "To be or not to be", (pause), " that is the question"
+	* "To be or not to be.... that is the question": 2 pauses: "To be or not to be", (pause), (pause), " that is the question"
+	* "To be or not to be. that is the question":    0 pauses: "To be or not to be. that is the question"
+	*
+	* @return the input split into multiple tokens. An empty-string token in the result indicates a pause.
+	*/
+	class func createUtterances(text: String) -> [AVSpeechUtterance] {
+		let voiceIdentifier = Settings.getVoiceIdentifier()
+		var result = [AVSpeechUtterance]()
+		// In a sequence of dots, we want to skip the first two.
+		var skippedDots = 0
+		var pause = TimeInterval(0)
+		var prevUtterance: AVSpeechUtterance? = nil
+		text.components(separatedBy: ".").forEach { token in
+			// The current token is a dot. It may or may not be used to pause.
+			if (token.isEmpty) {
+				// We've skipped at least two consecutive dots. We can now start adding all dots as
+				// pause tokens.
+				if (skippedDots >= 1) {
+					pause += PAUSE_DURATION_S
+					prevUtterance = nil
+				}
+				// Beginning of a dot sequence. We have to skip the first two dots.
+				else {
+					skippedDots += 1
+				}
+			}
+			// The current token is actual text to speak.
+			else {
+				var utterance: AVSpeechUtterance? = nil
+				// This is either the first text token of the entire input, or a text token after a pause token.
+				// We simply add it to the list.
+				if (prevUtterance == nil || prevUtterance!.speechString.isEmpty) {
+					utterance = createUtterance(text: token, voiceIdentifier: voiceIdentifier, preDelay: pause)
+					result.append(utterance!)
+				}
+				// The previous token was also actual text.
+				// Concatenate the previous token with this one, separating by a single period.
+				// This optimization allows us to minimize the number of tokens we'll return, and to rely
+				// on the sentence pausing of the TTS engine when less than 3 dots separate two sentences.
+				else {
+					utterance = createUtterance(text: "\(prevUtterance!.speechString).\(token)", voiceIdentifier: voiceIdentifier)
+					result[result.count - 1] = utterance!
+				}
+				prevUtterance = utterance
+				pause = 0
+				skippedDots = 0
+			}
+		}
+		return result
 	}
 }

--- a/PoetAssistantTests/TtsTest.swift
+++ b/PoetAssistantTests/TtsTest.swift
@@ -1,0 +1,127 @@
+/**
+Copyright (c) 2020 Carmen Alvarez
+
+This file is part of Poet Assistant.
+
+Poet Assistant is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Poet Assistant is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import AVFoundation
+import XCTest
+@testable import PoetAssistant
+
+class TtsTest: XCTestCase {
+
+	func testSplit1() {
+		testSplit(input: "To be or not to be", expectedUtterances: [AVSpeechUtterance(string: "To be or not to be")])
+	}
+
+	func testSplit2() {
+		testSplit(input: "To be or not to be.. that is the question", expectedUtterances: [AVSpeechUtterance(string: "To be or not to be. that is the question")])
+	}
+
+	func testSplit3() {
+		let expectedUtterance1 = AVSpeechUtterance(string: "To be or not to be")
+		let expectedUtterance2 = AVSpeechUtterance(string: " that is the question")
+		expectedUtterance2.preUtteranceDelay = 0.5
+
+		testSplit(input: "To be or not to be... that is the question", expectedUtterances: [expectedUtterance1, expectedUtterance2
+		])
+	}
+
+	func testSplit4() {
+		let expectedUtterance1 = AVSpeechUtterance(string: "To be or not to be")
+		let expectedUtterance2 = AVSpeechUtterance(string: " that is the question")
+		expectedUtterance2.preUtteranceDelay = 1.0
+
+		testSplit(input: "To be or not to be.... that is the question", expectedUtterances: [expectedUtterance1, expectedUtterance2
+		])
+	}
+
+	func testSplit5() {
+		let expectedUtterance1 = AVSpeechUtterance(string: "To be or not to be")
+		let expectedUtterance2 = AVSpeechUtterance(string: " that is the question")
+		expectedUtterance2.preUtteranceDelay = 1.5
+
+		testSplit(input: "To be or not to be..... that is the question", expectedUtterances: [expectedUtterance1, expectedUtterance2
+		])
+	}
+
+	func testSplit6() {
+		let expectedUtterance1 = AVSpeechUtterance(string: "To be or not to be")
+		let expectedUtterance2 = AVSpeechUtterance(string: " that is the question")
+		expectedUtterance2.preUtteranceDelay = 2.0
+
+		testSplit(input: "To be or not to be...... that is the question", expectedUtterances: [expectedUtterance1, expectedUtterance2
+		])
+	}
+
+	func testSplit7() {
+		let expectedUtterance1 = AVSpeechUtterance(string: "To be  ")
+		let expectedUtterance2 = AVSpeechUtterance(string: " or not to be")
+		expectedUtterance2.preUtteranceDelay = 0.5
+		let expectedUtterance3 = AVSpeechUtterance(string: " that is the question")
+		expectedUtterance3.preUtteranceDelay = 0.5
+
+		testSplit(input: "To be  ... or not to be... that is the question", expectedUtterances: [expectedUtterance1, expectedUtterance2, expectedUtterance3
+		])
+	}
+
+	func testSplit8() {
+		testSplit(input: "To be or not to be. That is the question", expectedUtterances: [AVSpeechUtterance(string: "To be or not to be. That is the question")])
+	}
+
+	func testSplit9() {
+		testSplit(input: "To be or not to be. That. is. the. question", expectedUtterances: [AVSpeechUtterance(string: "To be or not to be. That. is. the. question")])
+	}
+
+	func testSplit10() {
+		testSplit(input: "To be or not to be.. That.. is.. the.. question", expectedUtterances: [AVSpeechUtterance(string: "To be or not to be. That. is. the. question")])
+	}
+
+	func testSplit11() {
+		testSplit(input: "To be or not to be.\nThat..\nis.\n the\nquestion", expectedUtterances: [AVSpeechUtterance(string: "To be or not to be.\nThat.\nis.\n the\nquestion")])
+	}
+
+	func testSplitDotsOnly1() {
+		testSplit(input: ".", expectedUtterances:[])
+	}
+
+	func testSplitDotsOnly2() {
+		testSplit(input: "..", expectedUtterances:[])
+	}
+
+	func testSplitDotsOnly3() {
+		testSplit(input: "...", expectedUtterances:[])
+	}
+
+	func testSplitDotsOnly4() {
+		testSplit(input: "....", expectedUtterances:[])
+	}
+
+	func testEmpty() {
+		testSplit(input: "", expectedUtterances: [])
+	}
+
+	private func testSplit(input: String, expectedUtterances: [AVSpeechUtterance]) {
+		let actualUtterances = Tts.createUtterances(text: input)
+		XCTAssertEqual(expectedUtterances.count, actualUtterances.count)
+		if (expectedUtterances.count == actualUtterances.count) {
+			for i in 0..<expectedUtterances.count {
+				XCTAssertEqual(expectedUtterances[i].speechString, actualUtterances[i].speechString)
+				XCTAssertEqual(expectedUtterances[i].preUtteranceDelay, actualUtterances[i].preUtteranceDelay)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Port the logic from the android implementation:
* [TtsSplitter](https://github.com/caarmen/poet-assistant/blob/master/app/src/main/kotlin/ca/rmen/android/poetassistant/TtsSplitter.kt)
* [TestTtsSplitter](https://github.com/caarmen/poet-assistant/blob/master/app/src/test/java/ca/rmen/android/poetassistant/TestTtsSplitter.java)

Treat a  `...` in a text as a half-second pause.  Treat subsequent `.` as additional half-second pauses.