### PR TITLE
Prevent a crash trying to display a cell in the suggestions list while it's updating

### DIFF
--- a/PoetAssistant/src/search/controller/SearchSuggestionsController.swift
+++ b/PoetAssistant/src/search/controller/SearchSuggestionsController.swift
@@ -57,9 +57,12 @@ class SearchSuggestionsController: UITableViewController, UISearchResultsUpdatin
 	}
 	
 	func loadSuggestions(forQuery queryText: String?) {
-		fetchedResultsController = Suggestion.createSearchSuggestionsFetchResultsController(queryText: queryText)
-		fetchedResultsController?.performFetch { [weak self] in
-			self?.reloadData()
+		if (queryText != fetchedResultsController?.queryText) {
+			fetchedResultsController = Suggestion.createSearchSuggestionsFetchResultsController(queryText: queryText)
+			tableView.reloadData()
+			fetchedResultsController?.performFetch { [weak self] in
+				self?.reloadData()
+			}
 		}
 	}
 	private func reloadData() {

--- a/PoetAssistant/src/search/model/SuggestionsFetchedResultsControllerWrapper.swift
+++ b/PoetAssistant/src/search/model/SuggestionsFetchedResultsControllerWrapper.swift
@@ -34,7 +34,7 @@ class SuggestionsFetchedResultsControllerWrapper {
 	private static let SECTION_SUGGESTIONS = "suggestions_section_suggestions"
 	private static let SECTION_HISTORY = "suggestions_section_history"
 	private static let SECTION_DICTIONARY = "suggestions_section_dictionary"
-	private let queryText: String?
+	let queryText: String?
 	
 	init(queryText: String?) {
 		self.queryText = queryText


### PR DESCRIPTION
Steps to reproduce:
* Type some letters in the search bar so that there is more than one page of suggestions
* Scroll up and down so that the keyboard is hidden
* Tap into the search bar again
* Expected behavior: search results remain, no crash
* Actual behavior: crash

Fix:
* As soon as we create a new `fetchedResultsController`, invalidate the table view data, so there's no attempts to access indexes which don't exist
* Prevent refetching data unnecessarily by checking of the query text changed, before refetching